### PR TITLE
fix order of steps in setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ You'll need to have PostgreSQL setup and running on your machine. My favourite w
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
   * Create and setup the Event Store with `mix event_store.init`
+  * Create and migrate your database with `mix ecto.setup`
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ You'll need to have PostgreSQL setup and running on your machine. My favourite w
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
-  * Create and setup the Event Store with `mix event_store.init`
-  * Create and migrate your database with `mix ecto.setup`
+  * Create and migrate your database with `mix setup`
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule Honeydew.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup"],
+      setup: ["deps.get", "event_store.init", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "event_store.init": ["event_store.drop", "event_store.create", "event_store.init"],


### PR DESCRIPTION
hello,

this pr fixes the steps in the readme when setting up the dev environment.
To get everything up and running I had to run `mix event_store.init` before `mix ecto.setup`

PS: thanks for the repo! pretty useful to see some "real world" example of an application using this pattern 👍 